### PR TITLE
Implement a custom GroupTransformer class

### DIFF
--- a/MLutilities/preprocessing/impute.py
+++ b/MLutilities/preprocessing/impute.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from typing import Optional
+from typing import Optional, List
 from sklearn.linear_model import LinearRegression
 from sklearn.base import BaseEstimator, TransformerMixin
 
@@ -97,10 +97,10 @@ class LinearModelImputer(BaseEstimator, TransformerMixin):
 
         """
         X_copy = X.copy()
-      
+
         # extract instances with missing target values and their corresponding feature values
         feature_test = X_copy.loc[X_copy.loc[:, self.target].isna(), [self.feature]]
-      
+
         # predict and replace the missing target values using the trained linear regression model
         target_predict = self.linear_model.predict(feature_test)
         X_copy.loc[X_copy.loc[:, self.target].isna(), self.target] = target_predict
@@ -111,4 +111,103 @@ class LinearModelImputer(BaseEstimator, TransformerMixin):
         """
         Returns the output feature names after transformation (needed to use 'set_output(transform="pandas")')
         """
+        pass
+
+
+class GroupImputer(BaseEstimator, TransformerMixin):
+    """
+    Custom transformer for imputing missing values based on group-wise statistics.
+    It replaces missing values in the 'impute_feature' column of a DataFrame
+    by imputing the most common value within each group defined by the specified 'group_features'
+
+    Parameters:
+    -----------
+      impute_feature:
+        The name of the feature to be imputed (i.e., the feature with missing values).
+      group_features:
+        The names of the features used to define the groups for imputation.
+
+    Returns:
+    --------
+      A pandas DataFrame containing the 'impute_feature' with imputed missing values
+    """
+
+    def __init__(self, impute_feature: str, group_features: List[str]):
+        self.impute_feature = impute_feature
+        self.group_features = group_features
+
+    def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
+        """
+        Fits the imputer by calculating the most common value for the 'impute_feature' within each group.
+
+        Parameters:
+        -----------
+          X:
+            The input DataFrame containing the training data.
+          y:
+            The target variable (ignored).
+        """
+        X_copy = X.copy()
+
+        # check that group features does not have missing values
+        for feature in self.group_features:
+            if X_copy.loc[:, feature].isna().any():
+                raise ValueError(f"Column '{feature}' contains NaN values.")
+
+        # build group_features -> impute_feature mapping
+        self.group_mapping = (
+            X_copy.groupby(self.group_features)[self.impute_feature].describe().top
+        )
+
+        # if there is missing values in the mapping, replace them by the 'impute_feature' mode
+        self.impute_feature_mode = X_copy.loc[:, self.impute_feature].describe().top
+        if self.group_mapping.isna().any():
+            self.group_mapping.loc[self.group_mapping.isna()] = self.impute_feature_mode
+
+        return self
+
+    def transform(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
+        """
+        Imputes missing values in the 'impute_feature' by replacing them with the most common value within the group.
+
+        Parameters:
+          X (pd.DataFrame):
+            The input DataFrame to be transformed.
+
+          y (Optional[pd.Series]):
+            The target variable (ignored).
+
+        Returns:
+          The transformed DataFrame (only with 'impute_feature') with missing values imputed
+        """
+        X_copy = X.copy()
+
+        # get multi-index to sample from 'group_mapping'
+        index = (
+            X_copy.loc[X_copy[self.impute_feature].isna()]
+            .set_index(self.group_features)
+            .index
+        )
+
+        # initialize series with imputed values
+        imputed_values = pd.Series(index=index, dtype="object")
+
+        # if tuple index is not present in 'group_mapping', replace its value by 'impute_feature_mode'
+        diff_ids = index.difference(self.group_mapping.index)
+        if not diff_ids.empty:
+            for id in diff_ids:
+                imputed_values.loc[id] = self.impute_feature_mode
+
+        # sample values from group_mapping using the common tuple index
+        common_ids = index.intersection(self.group_mapping.index)
+        imputed_values.loc[common_ids] = self.group_mapping.get(common_ids)
+
+        # impute missing values
+        X_copy.loc[
+            X_copy[self.impute_feature].isna(), self.impute_feature
+        ] = imputed_values.values
+
+        return X_copy.loc[:, [self.impute_feature]]
+
+    def get_feature_names_out(self):
         pass

--- a/MLutilities/preprocessing/impute.py
+++ b/MLutilities/preprocessing/impute.py
@@ -165,18 +165,20 @@ class GroupImputer(BaseEstimator, TransformerMixin):
         Imputes missing values in the 'impute_feature' by replacing them with the most common value within the group.
 
         Parameters:
-          X (pd.DataFrame):
+        -----------
+          X:
             The input DataFrame to be transformed.
 
-          y (Optional[pd.Series]):
+          y:
             The target variable (ignored).
 
         Returns:
+        --------
           The transformed DataFrame (only with 'impute_feature') with missing values imputed
         """
         X_copy = X.copy()
 
-        # get multi-index to sample from 'group_mapping'
+        # get index to sample from 'group_mapping'
         index = (
             X_copy.loc[X_copy[self.impute_feature].isna()]
             .set_index(self.group_features)
@@ -186,13 +188,12 @@ class GroupImputer(BaseEstimator, TransformerMixin):
         # initialize series with imputed values
         imputed_values = pd.Series(index=index, dtype="object")
 
-        # if tuple index is not present in 'group_mapping', replace its value by 'impute_feature_mode'
+        # if index is not present in 'group_mapping' keys, replace its value by 'impute_feature_mode'
         diff_ids = index.difference(self.group_mapping.index)
         if not diff_ids.empty:
-            for id in diff_ids:
-                imputed_values.loc[id] = self.impute_feature_mode
+            imputed_values.loc[diff_ids.values] = self.impute_feature_mode
 
-        # sample values from group_mapping using the common tuple index
+        # sample values from group_mapping
         common_ids = index.intersection(self.group_mapping.index)
         imputed_values.loc[common_ids] = self.group_mapping.get(common_ids)
 

--- a/MLutilities/preprocessing/impute.py
+++ b/MLutilities/preprocessing/impute.py
@@ -64,11 +64,11 @@ class LinearModelImputer(BaseEstimator, TransformerMixin):
             raise ValueError("The feature column contains NaN values.")
 
         # get instances with impute_feature missing values
-        self.nan_instances = X_copy.loc[:, self.impute_feature].isna()
+        nan_instances = X_copy.loc[:, self.impute_feature].isna()
 
         # use instances with no missing impute_feature values to train the linear model
-        feature_train = X_copy.loc[~self.nan_instances, [self.feature]]
-        target_train = X_copy.loc[~self.nan_instances, self.impute_feature]
+        feature_train = X_copy.loc[~nan_instances, [self.feature]]
+        target_train = X_copy.loc[~nan_instances, self.impute_feature]
 
         # train the linear model
         self.linear_model.fit(feature_train, target_train)
@@ -92,12 +92,15 @@ class LinearModelImputer(BaseEstimator, TransformerMixin):
         """
         X_copy = X.copy().select_dtypes(include=np.number)
 
+        # get instances with impute_feature missing values
+        nan_instances = X_copy.loc[:, self.impute_feature].isna()
+
         # extract instances with missing impute_feature values and their corresponding feature values
-        feature_test = X_copy.loc[self.nan_instances, [self.feature]]
+        feature_test = X_copy.loc[nan_instances, [self.feature]]
 
         # predict and replace the missing impute_feature values using the trained linear regression model
         target_predict = self.linear_model.predict(feature_test)
-        X_copy.loc[self.nan_instances, self.impute_feature] = target_predict
+        X_copy.loc[nan_instances, self.impute_feature] = target_predict
 
         return X_copy.loc[:, [self.impute_feature]]
 


### PR DESCRIPTION
Main changes of this PR:

1. The inclusion of a new class called `GroupImputer `to impute missing values in the `impute_feature` column of a DataFrame by replacing them with the most common value within each group defined by the specified `group_features`. This class inherits from `sklearn.base.BaseEstimator` and `sklearn.base.TransformerMixin`, making it compatible with scikit-learn's transformer API. This allows us to integrate the `GroupImputer` into scikit-learn pipelines, enabling efficient data preprocessing and modeling.
2. Refactoring of the `LinearModelImputer`, adding a restriction to work only with numerical variables and updating the docstring to provide more comprehensive and informative documentation.